### PR TITLE
Implement append, prepend methods

### DIFF
--- a/src/Data/Arrays.php
+++ b/src/Data/Arrays.php
@@ -21,7 +21,7 @@ class Arrays implements \ArrayAccess
     /**
      * Determine array is accessible.
      *
-     * @param (mixed) $value Value to be check.
+     * @param mixed $value Value to be check.
      *
      * @since 3.0.0
      *
@@ -35,12 +35,12 @@ class Arrays implements \ArrayAccess
     /**
      * Determine array is (sqquential).
      *
-     * @param (array) $array Value to be check.
+     * @param array $array Value to be check.
      *
      * @since 3.0.0
      *
      * @return bool
-     */    
+     */
     public static function isSequential($array) :bool
     {
         return is_array($array) && !self::isAssoc($array) && !self::isMulti($array);
@@ -49,7 +49,7 @@ class Arrays implements \ArrayAccess
     /**
      * Determine array is Assoc.
      *
-     * @param (array) $value Value to be check.
+     * @param array $value Value to be check.
      *
      * @since 3.0.0
      *
@@ -59,25 +59,27 @@ class Arrays implements \ArrayAccess
     {
         return array_keys($array) !== range(0, count($array) - 1) && !self::isMulti($array);
     }
+
     /**
      * Determine array is multi-dimensional.
      *
-     * @param (array) $value Value to be check.
+     * @param array $value Value to be check.
      *
      * @since 3.0.0
      *
      * @return bool
      */
-     public static function isMulti(array $array) :bool
+    public static function isMulti(array $array) :bool
     {
         sort($array, SORT_REGULAR);
+
         return isset($array[0]) && is_array($array[0]);
     }
 
     /**
      * Determine array is accessible.
      *
-     * @param (mixed) $value Value to be check.
+     * @param mixed $value Value to be check.
      *
      * @since 3.0.0
      *
@@ -102,18 +104,19 @@ class Arrays implements \ArrayAccess
             }
         }
         $array = $value;
-        return $array;        
+
+        return $array;
     }
+
     public static function get(&$array, $default, $opr = null)
     {
-
     }
 
     /**
      * Determine if an item or items exist in an array using 'Operator' notation.
      *
-     * @param (array)       $array Default array
-     * @param (aray|string) $keys  Keys to search
+     * @param array        $array Default array
+     * @param array|string $keys  Keys to search
      *
      * @since 3.0.0
      *
@@ -121,13 +124,12 @@ class Arrays implements \ArrayAccess
      */
     public static function has($array, $keys)
     {
-
     }
 
     /**
      * Determine is given value is realy? array.
      *
-     * @param (mixed) $value Value to be checked.
+     * @param mixed $value Value to be checked.
      *
      * @since 3.0.0
      *
@@ -141,7 +143,7 @@ class Arrays implements \ArrayAccess
     /**
      * Convert a multi-dimensional array to assoc.
      *
-     * @param (array) $array Value to be converted.
+     * @param array $array Value to be converted.
      *
      * @since 3.0.0
      *
@@ -179,9 +181,9 @@ class Arrays implements \ArrayAccess
     /**
      * Converted a multi-dimensional associative array with `operator`.
      *
-     * @param (array)  $value   arrays.
-     * @param (string) $prepend Prepend value
-     * @param (string) $opr     Operator
+     * @param array  $value   arrays.
+     * @param string $prepend Prepend value
+     * @param string $opr     Operator
      *
      * @since 3.0.0
      *
@@ -192,7 +194,7 @@ class Arrays implements \ArrayAccess
         $results = [];
         foreach ($arrays as $key => $value) {
             if (self::isRealyArray($value) === true) {
-                $results = array_merge($results, self::multiToAssocWithSpecificOpr($value, $prepend.$key. $opr));
+                $results = array_merge($results, self::multiToAssocWithSpecificOpr($value, $prepend.$key.$opr));
             } else {
                 $results[$prepend.$key] = $value;
             }
@@ -204,9 +206,9 @@ class Arrays implements \ArrayAccess
     /**
      * Push an item onto the beginning of an array.
      *
-     * @param (mixed) $value Dafult array, where value to append.
-     * @param (mixed) $value Value to be append
-     * @param (mixed) $key   Key of value if array is assoc or multi-dimensional
+     * @param mixed $value Dafult array, where value to append.
+     * @param mixed $value Value to be append
+     * @param mixed $key   Key of value if array is assoc or multi-dimensional
      *
      * @since 3.0.0
      *
@@ -214,44 +216,49 @@ class Arrays implements \ArrayAccess
      */
     public static function prepend($array, $value, $key = null)
     {
+        if ($key === null) {
+            array_unshift($array, $value);
+        } else {
+            $array = array_merge([$key => $value], $array);
+        }
 
+        return $array;
     }
 
     /**
      * Push an item onto the end of an array.
      *
-     * @param (mixed) $value Dafult array, where value to append.
-     * @param (mixed) $value Value to be append
-     * @param (mixed) $key   Key of value if array is assoc or multi-dimensional
+     * @param mixed $value Dafult array, where value to append.
+     * @param mixed $value Value to be append
+     * @param mixed $key   Key of value if array is assoc or multi-dimensional
      *
      * @since 3.0.0
      *
      * @return bool
-     */    
+     */
     public static function append($array, $value, $key = null)
     {
-
+        return array_merge($array, [$key => $value]);
     }
 
     /**
      * Get the unique elements of array with key => pair.
      *
-     * @param (array) $array Array ot evaulated
+     * @param array $array Array ot evaulated
      *
      * @since 3.0.0
      *
      * @return array
      */
-    public function unique(..$array)
+    public function unique(...$array)
     {
-
     }
 
     /**
      * Get a subset of the items from the given array.
      *
-     * @param (array) $array Array to be evaulated.
-     * @param (mixed) $keys Keys
+     * @param array $array Array to be evaulated.
+     * @param mixed $keys  Keys
      *
      * @since 3.0.0
      *
@@ -260,21 +267,20 @@ class Arrays implements \ArrayAccess
     public function subSetOfArray(array $array, $keys)
     {
     }
+
     public function offsetExists($offset) :bool
     {
-
     }
+
     public function offsetGet($offset)
     {
-
     }
 
     public function offsetSet($offset, $value) :void
     {
-
     }
+
     public function offsetUnset($offset) :void
     {
-
-    }   
+    }
 }


### PR DESCRIPTION
# Changed log

- It's about issue #185 and PR #187.
- Implement `prepend` and `append` methods.
I'm not sure that these methods are the proper way to implement.
Please review them and modify them if possible.
- Other methods implementation that I'm not sure what current approach can be satisfied with this class.
This should be up to @Lablnet to implement/consider them.
- We should follow the `PHPDoc` comment annotations and other classes on this `src` folder also have the same problem.

To keep dot array class lightweight, I think it's fine to implement the `set`, `get` and `has` methods without implementing `\ArrayAccess` interface.