### PR TITLE
Fix Hashing class test in Travis CI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .github
 /vendor
 /.phpintel
+/.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,11 @@
             <directory>Tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
     <php>
         <const name="PHPUNIT_RUNNING" value="true"/>
     </php>

--- a/src/Hashing/Argon2IdHashing.php
+++ b/src/Hashing/Argon2IdHashing.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the Zest Framework.
+ *
+ * @author   Muhammad Umer Farooq <lablnet01@gmail.com>
+ * @author-profile https://www.facebook.com/Muhammadumerfarooq01/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ * @since 3.0.0
+ *
+ * @license MIT
+ */
+
+namespace Zest\Hashing;
+
+class Argon2IdHashing extends ArgonHashing
+{
+    /**
+     * Get the algroithm.
+     *
+     * @since 3.0.0
+     *
+     * @return \Constant
+     */
+    protected function algorithm()
+    {
+        return \PASSWORD_ARGON2ID;
+    }
+
+    /**
+     * Get the algroithm keys.
+     *
+     * @since 3.0.0
+     *
+     * @return string
+     */
+    protected function algorithmKeys()
+    {
+        return 'argon2id';
+    }
+}

--- a/src/Hashing/ArgonHashing.php
+++ b/src/Hashing/ArgonHashing.php
@@ -57,13 +57,13 @@ class ArgonHashing extends AbstractHashing
     /**
      * __construct.
      *
-     * @param (array) $options
+     * @param array $options
      *
      * @since 3.0.0
      */
-    public function __construct(array $options)
+    public function __construct(array $options = null)
     {
-        $this->setMemory($options['memory'])->setTime($options['time'])->setThreads($options['threads']);
+        $this->setMemory($options['memory'] ?? $this->memory)->setTime($options['time'] ?? $this->time)->setThreads($options['threads'] ?? $this->threads);
 
         $this->verifyAlgorithm = (isset($options['verify'])) ? $options['verify'] : false;
     }
@@ -71,8 +71,8 @@ class ArgonHashing extends AbstractHashing
     /**
      * Verify the hash value.
      *
-     * @param (string) $original
-     * @param (string) $hash
+     * @param string $original
+     * @param string $hash
      *
      * @since 3.0.0
      *
@@ -90,8 +90,8 @@ class ArgonHashing extends AbstractHashing
     /**
      * Generate the hash.
      *
-     * @param (string)         $original
-     * @param (array) optional $options
+     * @param string $original
+     * @param array  $options
      *
      * @since 3.0.0
      *
@@ -119,8 +119,8 @@ class ArgonHashing extends AbstractHashing
     /**
      * Check if the given hash has been hashed using the given options.
      *
-     * @param (string)         $hash
-     * @param (array) optional $options
+     * @param string $hash
+     * @param array  $options
      *
      * @since 3.0.0
      *
@@ -142,7 +142,7 @@ class ArgonHashing extends AbstractHashing
     /**
      * Set the memory.
      *
-     * @param (int) $memory
+     * @param int $memory
      *
      * @since 3.0.0
      *
@@ -158,7 +158,7 @@ class ArgonHashing extends AbstractHashing
     /**
      * Set the time.
      *
-     * @param (int) $time
+     * @param int $time
      *
      * @since 3.0.0
      *
@@ -174,7 +174,7 @@ class ArgonHashing extends AbstractHashing
     /**
      * Set the threads.
      *
-     * @param (int) $threads
+     * @param int $threads
      *
      * @since 3.0.0
      *
@@ -232,20 +232,7 @@ class ArgonHashing extends AbstractHashing
      */
     protected function algorithm()
     {
-        $algo = __config()->hashing->driver;
-
-        switch (strtolower($algo)) {
-            case 'argon2i':
-                $algorithm = \PASSWORD_ARGON2I;
-                break;
-            case 'argon2id':
-                $algorithm = \PASSWORD_ARGON2ID;
-            default:
-                $algorithm = \PASSWORD_ARGON2ID;
-                break;
-        }
-
-        return $algorithm;
+        return \PASSWORD_ARGON2I;
     }
 
     /**
@@ -257,19 +244,6 @@ class ArgonHashing extends AbstractHashing
      */
     protected function algorithmKeys()
     {
-        $algo = __config()->hashing->driver;
-
-        switch (strtolower($algo)) {
-            case 'argon2i':
-                $algorithm = 'argon2i';
-                break;
-            case 'argon2id':
-                $algorithm = 'argon2id';
-            default:
-                $algorithm = 'argon2id';
-                break;
-        }
-
-        return $algorithm;
+        return 'argon2i';
     }
 }

--- a/src/Hashing/Hash.php
+++ b/src/Hashing/Hash.php
@@ -37,8 +37,15 @@ class Hash
         $driver = __config()->hashing->driver;
         if ($driver === 'bcrypt') {
             self::$driver = new BcryptHashing(['cost' => __config()->hashing->bcrypt->cost]);
-        } elseif ($driver === 'argon2id' || $driver === 'argon2i') {
+        } elseif ($driver === 'argon2i') {
             self::$driver = new ArgonHashing([
+                'memory'  => __config()->hashing->argon->memory,
+                'time'    => __config()->hashing->argon->time,
+                'threads' => __config()->hashing->argon->threads,
+                'verify'  => $verify,
+            ]);
+        } elseif ($driver === 'argon2id') {
+            self::$driver = new Argon2IdHashing([
                 'memory'  => __config()->hashing->argon->memory,
                 'time'    => __config()->hashing->argon->time,
                 'threads' => __config()->hashing->argon->threads,

--- a/src/Hashing/Hashing.php
+++ b/src/Hashing/Hashing.php
@@ -37,8 +37,15 @@ class Hashing
         $driver = __config()->hashing->driver;
         if ($driver === 'bcrypt') {
             $this->driver = new BcryptHashing(['cost' => __config()->hashing->bcrypt->cost]);
-        } elseif ($driver === 'argon2id' || $driver === 'argon2i') {
+        } elseif ($driver === 'argon2i') {
             $this->driver = new ArgonHashing([
+                'memory'  => __config()->hashing->argon->memory,
+                'time'    => __config()->hashing->argon->time,
+                'threads' => __config()->hashing->argon->threads,
+                'verify'  => $verify,
+            ]);
+        } elseif ($driver === 'argon2id') {
+            $this->driver = new Argon2IdHashing([
                 'memory'  => __config()->hashing->argon->memory,
                 'time'    => __config()->hashing->argon->time,
                 'threads' => __config()->hashing->argon->threads,


### PR DESCRIPTION
# Changed log
- Resolves issue #191.
- Fix `Hashing` class test.
- The `Hashing` and `Hash` classes shouldn't be tested because they're the `dispatcher` and `manager`.
They dispatch the current algorithm to do password hashing and the algorithm name is defined by `config` array.