### PR TITLE
Fix failed testRandom assertion

### DIFF
--- a/Tests/Data/ArraysTest.php
+++ b/Tests/Data/ArraysTest.php
@@ -255,6 +255,6 @@ class ArraysTest extends TestCase
     public function testRandom()
     {
         $random = Arrays::random(['foo', 'bar', 'baz'], 1);
-        $this->assertContains($random, ['foo', 'bar', 'baz']);
+        $this->assertContains($random[0], ['foo', 'bar', 'baz']);
     }
 }


### PR DESCRIPTION
# Changed log
- Fix `Arrays::random` method test.
- The first parameter is in `PHPUnit\Framework\TestCase::assertContains` method should be specific value.
The `Array::random` method will return the array type with one value and we have to get that value and pass to the first parameter in `assertContains` method.
- It's related to issue #223.