### PR TITLE
Add mbstring extension to check it's available

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "keywords": ["framework", "zest"],
     "license": "MIT",
     "require": {
-        "php": "^7.2"
+        "php": "^7.2",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8"


### PR DESCRIPTION
# How to report a issue on GitHub
- Add the `ext-mbstring` to check this extension is available during composer installation.