### PR TITLE
Fix Router syntax on line 36

### DIFF
--- a/src/Component/Router.php
+++ b/src/Component/Router.php
@@ -33,7 +33,7 @@ class Router extends Component
         $file = new FileHandling();
         $diskScan = array_diff(scandir(route('com')), ['..', '.']);
         foreach ($diskScan as $scans) {
-            $configFile = route('com'.$scans.'/component.json';
+            $configFile = route('com'.$scans.'/component.json');
             if (file_exists($configFile)) {
                 $c = $file->open($configFile, 'readOnly')->read();
                 $file->close();


### PR DESCRIPTION
# How to report a issue on GitHub

- Fix the syntax error of `Router` class on line `36`.