### PR TITLE
Member ttl has private access

### DIFF
--- a/src/Cache/Adapter/APC.php
+++ b/src/Cache/Adapter/APC.php
@@ -80,7 +80,7 @@ class APC extends AbstractAdapter
     {
         $cache = [
             'start' => time(),
-            'ttl'   => ($ttl !== null) ? (int) $ttl : $this->ttl,
+            'ttl'   => ($ttl !== null) ? (int) $ttl : $this->getTtl(),
             'value' => $value,
         ];
 

--- a/src/Cache/Adapter/APCU.php
+++ b/src/Cache/Adapter/APCU.php
@@ -80,7 +80,7 @@ class APCU extends AbstractAdapter
     {
         $cache = [
             'start' => time(),
-            'ttl'   => ($ttl !== null) ? (int) $ttl : $this->ttl,
+            'ttl'   => ($ttl !== null) ? (int) $ttl : $this->getTtl(),
             'value' => $value,
         ];
 

--- a/src/Cache/Adapter/FileCache.php
+++ b/src/Cache/Adapter/FileCache.php
@@ -77,7 +77,7 @@ class FileCache extends AbstractAdapter
             $fileHandling = new FileHandling();
             $fileHandling->open($cacheFile, 'writeAppend')->write(json_encode([
                 'start' => time(),
-                'ttl'   => ($ttl !== null) ? (int) $ttl : $this->ttl,
+                'ttl'   => ($ttl !== null) ? (int) $ttl : $this->getTtl(),
                 'value' => $value,
             ]));
             $fileHandling->close();

--- a/src/Cache/Adapter/Memcache.php
+++ b/src/Cache/Adapter/Memcache.php
@@ -111,7 +111,7 @@ class Memcache extends AbstractAdapter
     {
         $cache = [
             'start' => time(),
-            'ttl'   => ($ttl !== null) ? (int) $ttl : $this->ttl,
+            'ttl'   => ($ttl !== null) ? (int) $ttl : $this->getTtl(),
             'value' => $value,
         ];
 

--- a/src/Cache/Adapter/Memcached.php
+++ b/src/Cache/Adapter/Memcached.php
@@ -148,7 +148,7 @@ class Memcached extends AbstractAdapter
     {
         $cache = [
             'start' => time(),
-            'ttl'   => ($ttl !== null) ? (int) $ttl : $this->ttl,
+            'ttl'   => ($ttl !== null) ? (int) $ttl : $this->getTtl(),
             'value' => $value,
         ];
 

--- a/src/Cache/Adapter/Redis.php
+++ b/src/Cache/Adapter/Redis.php
@@ -115,7 +115,7 @@ class Redis extends AbstractAdapter
     {
         $cache = [
             'start' => time(),
-            'ttl'   => ($ttl !== null) ? (int) $ttl : $this->ttl,
+            'ttl'   => ($ttl !== null) ? (int) $ttl : $this->getTtl(),
             'value' => $value,
         ];
         if ($cache['ttl'] != 0) {

--- a/src/Cache/Adapter/SessionCache.php
+++ b/src/Cache/Adapter/SessionCache.php
@@ -72,7 +72,7 @@ class SessionCache extends AbstractAdapter
     {
         $_SESSION['__CACHE__'][$key] = json_encode([
             'start' => time(),
-            'ttl'   => ($ttl !== null) ? (int) $ttl : $this->ttl,
+            'ttl'   => ($ttl !== null) ? (int) $ttl : $this->getTtl(),
             'value' => $value,
         ]);
 


### PR DESCRIPTION
Member has private access and can`t not by use in:
- APC@saveItem
- APCU@saveItem
- FileCache@saveItem
- Memcache@saveItem
- Memcached@saveItem
- Redis@saveItem
- SessionCache@saveItem