### PR TITLE
Bugfix: $key is private

### DIFF
--- a/src/Encryption/Adapter/AbstractAdapter.php
+++ b/src/Encryption/Adapter/AbstractAdapter.php
@@ -27,7 +27,7 @@ abstract class AbstractAdapter implements AbstractAdapterContract
      *
      * @var key
      */
-    private $key;
+    protected $key;
 
     /**
      * Encrypt the message.


### PR DESCRIPTION
Member: $key is private and can`t not by use in SodiumEncryption
