### PR TITLE
Add isBase64 and substring methods to Str class

### DIFF
--- a/Tests/Data/StrTest.php
+++ b/Tests/Data/StrTest.php
@@ -60,6 +60,7 @@ class StrTest extends TestCase
     public function testSubstring()
     {
         $this->assertSame('def', Str::substring('abcdef', 3, 3));
+        $this->assertSame('def', Str::substring('abcdef', 3));
         $this->assertSame('ĄaśćŻ', Str::substring('AAaaĄaśćŻŹ', 4, 5));
         $this->assertSame('AbCdEf', Str::substring('AbCdEf', 0, 6, 'iso-8859-1'));
         $this->assertSame('ćŻŹ', Str::substring('ĄaśćŻŹ', 3, 3));

--- a/Tests/Data/StrTest.php
+++ b/Tests/Data/StrTest.php
@@ -48,4 +48,21 @@ class StrTest extends TestCase
         $this->assertSame('UPPERcase', Str::ConvertCase('upperCASE', 'UTF-8'));
         $this->assertSame('LOWERCASE IN string', Str::ConvertCase('lowercase in STRING', 'UTF-8'));
     }
+
+    public function testIsBase64()
+    {
+        $this->assertTrue(Str::isBase64('ejJlQUVFSFpCcUpjVDNlWW5WcEd0QQ=='));
+        $this->assertTrue(Str::isBase64('dGhpc2lzdmFsaWR0ZXN0ZGF0YQ=='));
+        $this->assertFalse(Str::isBase64('aWFtd3Jvbmc==='));
+        $this->assertFalse(Str::isBase64('thisisnobase64encodedstring'));
+    }
+
+    public function testSubstring()
+    {
+        $this->assertSame('def', Str::substring('abcdef', 3, 3));
+        $this->assertSame('ĄaśćŻ', Str::substring('AAaaĄaśćŻŹ', 4, 5));
+        $this->assertSame('AbCdEf', Str::substring('AbCdEf', 0, 6, 'iso-8859-1'));
+        $this->assertSame('ćŻŹ', Str::substring('ĄaśćŻŹ', 3, 3));
+        $this->assertNotSame('ćŻŹ', Str::substring('ĄaśćŻŹ', 3, 3, 'iso-8859-1'));
+    }
 }

--- a/src/Data/Str.php
+++ b/src/Data/Str.php
@@ -169,4 +169,31 @@ class Str implements StrContract
         // returns original string when mbstring is not active.
         return $str;
     }
+
+    /**
+     * Checks if given string is a valid Base64 encoded string
+     *
+     * @param string $str String to be tested
+     *
+     * @return bool wether it is a valid base64 encoded string or not
+     */
+    public static function isBase64(string $str): bool
+    {
+        return ($str === base64_encode(base64_decode($str)));
+    }
+
+    /**
+     * Return only a portion of given string
+     *
+     * @param string $str input string to process
+     * @param int $start where to start the cut
+     * @param int|null $length how many characters to return
+     * @param string $encoding optional encoding to use
+     *
+     * @return string
+     */
+    public static function substring(string $str, int $start, int $length = null, string $encoding = 'UTF-8'): string
+    {
+        return mb_substr($str, $start, $length, $encoding);
+    }
 }

--- a/src/Data/Str.php
+++ b/src/Data/Str.php
@@ -185,10 +185,10 @@ class Str implements StrContract
     /**
      * Return only a portion of given string.
      *
-     * @param string   $str      input string to process
-     * @param int      $start    where to start the cut
-     * @param int|null $length   how many characters to return
-     * @param string   $encoding optional encoding to us
+     * @param string      $str      input string to process
+     * @param int         $start    where to start the cut
+     * @param int|null    $length   how many characters to return
+     * @param string|null $encoding optional encoding to use
      *
      * @return string
      */

--- a/src/Data/Str.php
+++ b/src/Data/Str.php
@@ -171,7 +171,7 @@ class Str implements StrContract
     }
 
     /**
-     * Checks if given string is a valid Base64 encoded string
+     * Checks if given string is a valid Base64 encoded string.
      *
      * @param string $str String to be tested
      *
@@ -179,16 +179,16 @@ class Str implements StrContract
      */
     public static function isBase64(string $str): bool
     {
-        return ($str === base64_encode(base64_decode($str)));
+        return $str === base64_encode(base64_decode($str));
     }
 
     /**
-     * Return only a portion of given string
+     * Return only a portion of given string.
      *
-     * @param string $str input string to process
-     * @param int $start where to start the cut
-     * @param int|null $length how many characters to return
-     * @param string $encoding optional encoding to use
+     * @param string   $str      input string to process
+     * @param int      $start    where to start the cut
+     * @param int|null $length   how many characters to return
+     * @param string   $encoding optional encoding to us
      *
      * @return string
      */

--- a/src/Data/Str.php
+++ b/src/Data/Str.php
@@ -192,8 +192,8 @@ class Str implements StrContract
      *
      * @return string
      */
-    public static function substring(string $str, int $start, int $length = null, string $encoding = 'UTF-8'): string
+    public static function substring(string $str, int $start, int $length = null, $encoding = null): string
     {
-        return mb_substr($str, $start, $length, $encoding);
+        return mb_substr($str, $start, $length, self::encoding($encoding));
     }
 }


### PR DESCRIPTION
As requested in https://github.com/zestframework/Zest_Framework/issues/271 I added two new statics to:

a) check if a string is a valid base64 encoded string
b) return a substring of given string

and added corresponding tests as well.
