### PR TITLE
feat: add the option to output assoc arrays fixes #261

### DIFF
--- a/Tests/Data/ArraysTest.php
+++ b/Tests/Data/ArraysTest.php
@@ -116,6 +116,13 @@ class ArraysTest extends TestCase
         $this->assertEquals($array, ['name' => 'Alex', 'languages@cpp' => true]);
     }
 
+    public function testMultiToAssocWithSpecificOprWithAssocArray()
+    {
+        $opr = '@';
+        $array = Arrays::multiToAssocWithSpecificOpr(['foo' => ['bar' => ['one', 'three', 'two']]], $opr, true);
+        $this->assertEquals(['foo@bar' => ['one', 'three', 'two']], $array);
+    }
+
     public function testExcept()
     {
         $array = ['name' => 'Alex', 'age' => 18];

--- a/Tests/Data/ArraysTest.php
+++ b/Tests/Data/ArraysTest.php
@@ -101,6 +101,12 @@ class ArraysTest extends TestCase
         $this->assertEquals($array, ['name' => 'Alex', 'languages.cpp' => true]);
     }
 
+    public function testDotWithAssocArray()
+    {
+        $array = Arrays::dot(['foo' => ['bar' => ['one', 'three', 'two']]], true);
+        $this->assertEquals(['foo.bar' => ['one', 'three', 'two']], $array);
+    }
+
     public function testMultiToAssocWithSpecificOpr()
     {
         $opr = '@';

--- a/src/Contracts/Data/Arrays.php
+++ b/src/Contracts/Data/Arrays.php
@@ -126,16 +126,16 @@ interface Arrays
      */
     public static function has($array, $keys = null, $opr = null);
 
-     /**
-      * Converted a multi-dimensional associative array with `dot`.
-      *
-      * @param array $arrays      Arrays.
-      * @param bool  $assocOutput Switch to output assoc arrays.
-      *
-      * @since 3.0.0
-      *
-      * @return bool
-     */
+    /**
+     * Converted a multi-dimensional associative array with `dot`.
+    *
+    * @param array $arrays      Arrays.
+    * @param bool  $assocOutput Switch to output assoc arrays.
+    *
+    * @since 3.0.0
+    *
+    * @return bool
+    */
     public static function dot(array $arrays, bool $assocOutput = false);
 
     /**

--- a/src/Contracts/Data/Arrays.php
+++ b/src/Contracts/Data/Arrays.php
@@ -126,29 +126,31 @@ interface Arrays
      */
     public static function has($array, $keys = null, $opr = null);
 
-    /**
-     * Converted a multi-dimensional associative array with `dot`.
-     *
-     * @param array $arrays Arrays.
-     * @param bool  $assocOutput Switch to output assoc arrays.
-     * 
-     * @since 3.0.0
-     *
-     * @return bool
+     /**
+      * Converted a multi-dimensional associative array with `dot`.
+      *
+      * @param array $arrays      Arrays.
+      * @param bool  $assocOutput Switch to output assoc arrays.
+      *
+      * @since 3.0.0
+      *
+      * @return bool
      */
     public static function dot(array $arrays, bool $assocOutput = false);
 
     /**
      * Converted a multi-dimensional associative array with `operator`.
      *
-     * @param array  $arrays Arrays.
-     * @param string $opr    Operator.
+     * @param array  $arrays      Arrays.
+     * @param string $opr         Operator.
+     * @param bool   $assocOutput Switch to output assoc arrays.
+     * @param string $_key        the previous key of the object
      *
      * @since 3.0.0
      *
      * @return array
      */
-    public static function multiToAssocWithSpecificOpr(array $arrays, $opr = null);
+    public static function multiToAssocWithSpecificOpr(array $arrays, $opr = null, bool $assocOutput = false, string $_key = null);
 
     /**
      * Remove one or many array items from a given array using "operator" notation.

--- a/src/Contracts/Data/Arrays.php
+++ b/src/Contracts/Data/Arrays.php
@@ -128,14 +128,14 @@ interface Arrays
 
     /**
      * Converted a multi-dimensional associative array with `dot`.
-    *
-    * @param array $arrays      Arrays.
-    * @param bool  $assocOutput Switch to output assoc arrays.
-    *
-    * @since 3.0.0
-    *
-    * @return bool
-    */
+     *
+     * @param array $arrays      Arrays.
+     * @param bool  $assocOutput Switch to output assoc arrays.
+     *
+     * @since 3.0.0
+     *
+     * @return bool
+     */
     public static function dot(array $arrays, bool $assocOutput = false);
 
     /**

--- a/src/Contracts/Data/Arrays.php
+++ b/src/Contracts/Data/Arrays.php
@@ -130,12 +130,13 @@ interface Arrays
      * Converted a multi-dimensional associative array with `dot`.
      *
      * @param array $arrays Arrays.
-     *
+     * @param bool  $assocOutput Switch to output assoc arrays.
+     * 
      * @since 3.0.0
      *
      * @return bool
      */
-    public static function dot(array $arrays);
+    public static function dot(array $arrays, bool $assocOutput = false);
 
     /**
      * Converted a multi-dimensional associative array with `operator`.

--- a/src/Data/Arrays.php
+++ b/src/Data/Arrays.php
@@ -274,10 +274,10 @@ class Arrays implements ArraysContract
     /**
      * Converted a multi-dimensional associative array with `operator`.
      *
-     * @param array  $arrays Arrays.
-     * @param string $opr    Operator.
-     * @param bool  $assocOutput Switch to output assoc arrays.
-     * @param string $_key the previous key of the object
+     * @param array  $arrays      Arrays.
+     * @param string $opr         Operator.
+     * @param bool   $assocOutput Switch to output assoc arrays.
+     * @param string $_key        the previous key of the object
      *
      * @since 3.0.0
      *
@@ -287,7 +287,7 @@ class Arrays implements ArraysContract
     {
         $results = [];
         foreach ($arrays as $key => $value) {
-            $key = ($assocOutput === true ? $_key . $key : $key);
+            $key = ($assocOutput === true ? $_key.$key : $key);
             if (self::isReallyArray($value) === true) {
                 $assocKey = ($assocOutput === true ? $opr : $key.$opr);
                 $results = array_merge(
@@ -296,7 +296,7 @@ class Arrays implements ArraysContract
                         $value,
                         $assocKey,
                         $assocOutput,
-                        $key . $opr
+                        $key.$opr
                     )
                 );
             } elseif ($assocOutput === true) {

--- a/src/Data/Arrays.php
+++ b/src/Data/Arrays.php
@@ -301,12 +301,13 @@ class Arrays implements ArraysContract
                     )
                 );
             } elseif ($assocOutput === true) {
-                // gets pull off the last dot that is added
-                $_key = preg_replace('/(\.$)/', '', $_key);
+                // gets pull off the last $opr that is added
+                $regex = '/(\\'.$opr.'$)/';
+                $_key = preg_replace($regex, '', $_key);
                 $results[$_key][] = $value;
             } else {
                 $key = $opr.$key;
-                $key = ($key[0] === '.' || $key[0] === '@' ? substr($key, 1) : $key);
+                $key = ($key[0] === $opr ? substr($key, 1) : $key);
                 $results[$key] = $value;
             }
         }

--- a/src/Data/Arrays.php
+++ b/src/Data/Arrays.php
@@ -261,32 +261,48 @@ class Arrays implements ArraysContract
      * Converted a multi-dimensional associative array with `dot`.
      *
      * @param array $arrays Arrays.
-     *
+     * @param bool  $assocOutput Switch to output assoc arrays.
+     * 
      * @since 3.0.0
      *
-     * @return bool
+     * @return array
      */
-    public static function dot(array $arrays)
+    public static function dot(array $arrays, bool $assocOutput = false)
     {
-        return self::multiToAssocWithSpecificOpr($arrays, '.');
+        return self::multiToAssocWithSpecificOpr($arrays, '.', $assocOutput);
     }
-
     /**
      * Converted a multi-dimensional associative array with `operator`.
      *
      * @param array  $arrays Arrays.
      * @param string $opr    Operator.
+     * @param bool  $assocOutput Switch to output assoc arrays.
+     * @param string $_key the previous key of the object
      *
      * @since 3.0.0
      *
      * @return array
      */
-    public static function multiToAssocWithSpecificOpr(array $arrays, $opr = null)
+    public static function multiToAssocWithSpecificOpr(array $arrays, $opr = null, bool $assocOutput = false, string $_key = null)
     {
         $results = [];
         foreach ($arrays as $key => $value) {
+            $key = ($assocOutput === true ? $_key . $key : $key);
             if (self::isReallyArray($value) === true) {
-                $results = array_merge($results, self::multiToAssocWithSpecificOpr($value, $key.$opr));
+                $assocKey = ($assocOutput === true ? $opr : $key.$opr);
+                $results = array_merge(
+                    $results,
+                    self::multiToAssocWithSpecificOpr(
+                        $value,
+                        $assocKey,
+                        $assocOutput,
+                        $key . $opr
+                    )
+                );
+            } elseif ($assocOutput === true) {
+                // gets pull off the last dot that is added
+                $_key = preg_replace('/(\.$)/', '', $_key);
+                $results[$_key][] = $value;
             } else {
                 $key = $opr.$key;
                 $key = ($key[0] === '.' || $key[0] === '@' ? substr($key, 1) : $key);

--- a/src/Data/Arrays.php
+++ b/src/Data/Arrays.php
@@ -271,6 +271,7 @@ class Arrays implements ArraysContract
     {
         return self::multiToAssocWithSpecificOpr($arrays, '.', $assocOutput);
     }
+
     /**
      * Converted a multi-dimensional associative array with `operator`.
      *

--- a/src/Data/Arrays.php
+++ b/src/Data/Arrays.php
@@ -260,9 +260,9 @@ class Arrays implements ArraysContract
     /**
      * Converted a multi-dimensional associative array with `dot`.
      *
-     * @param array $arrays Arrays.
+     * @param array $arrays      Arrays.
      * @param bool  $assocOutput Switch to output assoc arrays.
-     * 
+     *
      * @since 3.0.0
      *
      * @return array


### PR DESCRIPTION
This PR will add the ability to the `Zest\Data\Arrays::class` to output associative arrays when they are present at the end of a file.

For references and further discussion of this please look at #261 for the test data set.

The output of using this edited method is backwards compatible, it can be opted into for getting the different output.

An example: 
The syntax to access that would be:
```php
$array = new Arrays;
var_export($array->dot($dataSets, true));
```

```php
[
     "files.mine.type" => [
       "application/x-zip-compressed",
       "application/msword",
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "image/gif",
       "image/jpeg",
       "image/jpeg",
       "audio/mpeg",
       "video/mp4",
       "application/pdf",
       "image/png",
       "application/zip",
       "application/et-stream",
       "image/x-icon",
       "image/icon",
       "image/svg+xml",
     ],
     "files.types.image" => [
       "jpg",
       "png",
       "jpeg",
       "gif",
       "ico",
       "svg",
     ],
     "files.types.zip" => [
       "zip",
       "tar",
       "7zip",
       "rar",
     ],
     "files.types.docs" => [
       "pdf",
       "docs",
       "docx",
     ],
     "files.types.media" => [
       "mp4",
       "mp3",
       "wav",
       "3gp",
     ],
   ]
```