### PR TITLE
Rename Expection to Exception.

### DIFF
--- a/src/Common/Logger/Logger.php
+++ b/src/Common/Logger/Logger.php
@@ -179,7 +179,7 @@ class Logger extends AbstractLogger
      * @oaram (string)    $message Error message
      *
      * @param (array)     $context   Contextual array
-     * @param (Expection) $exception Exception
+     * @param (Exception) $exception Exception
      *
      * @since 2.0.3
      *

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -14,11 +14,11 @@
  * @license MIT
  */
 
-namespace Zest\Expection;
+namespace Zest\Exception;
 
 use Zest\Whoops\Whoops;
 
-class Expection
+class Exception
 {
     /**
      * __construct.

--- a/src/Whoops/Whoops.php
+++ b/src/Whoops/Whoops.php
@@ -66,7 +66,7 @@ class Whoops
     }
 
     /**
-     * expection handler.
+     * Exception handler.
      *
      * @since 3.0.0
      *


### PR DESCRIPTION
"Expection" isn't a word in English. I'm assuming that that was a typo, and that "Exception" is what was meant. This pull request just renames the class and changes references from the old class name to the new class name accordingly. :-)