### PR TITLE
Add an adapter interface.

### DIFF
--- a/src/Archive/Adapter/AdapterInterface.php
+++ b/src/Archive/Adapter/AdapterInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of the Zest Framework.
+ *
+ * @author Muhammad Umer Farooq (Malik) <mumerfarooqlablnet01@gmail.com>
+ *
+ * @link https://lablnet.github.io/profile/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ * @license MIT
+ *
+ * @since 3.0.0
+ */
+
+namespace Zest\Archive\Adapter;
+
+interface AdapterInterface
+{
+    /**
+     * Open and extract the archive.
+     *
+     * @param (string) $file   The file that you want uncompress/open.
+     * @param (string) $target Where to extract the file.
+     * @param (bool)   $delete True to delete the file; False to not delete it.
+     *
+     * @return bool
+     */
+    public function extract(string $file = '', string $target = '', bool $delete = false): bool;
+
+    /**
+     * Compress the file to an archive.
+     *
+     * @param (mixed)  $files       The file(/s) that you want compress.
+     * @param (string) $destination The file destination.
+     * @param (bool)   $overwrite   True to delete the file; False to not delete it.
+     *
+     * @return bool
+     */
+    public function compress($files, string $destination = '', bool $overwrite = false): bool;
+}

--- a/src/Archive/Adapter/Bzip.php
+++ b/src/Archive/Adapter/Bzip.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of the Zest Framework.
  *
@@ -17,20 +16,20 @@
 
 namespace Zest\Archive\Adapter;
 
-class Bzip
+class Bzip extends AdapterInterface
 {
     /**
-     * Open zip extract zip.
+     * Open and extract the archive.
      *
-     * @param (string) $file   file that you want uncompress/open
-     * @param (string) $target where you extract file
-     * @param (bool)   $delete true delete zip file false not delete
+     * @param (string) $file   The file that you want uncompress/open.
+     * @param (string) $target Where to extract the file.
+     * @param (bool)   $delete True to delete the file; False to not delete it.
      *
      * @since 1.0.0
      *
      * @return bool
      */
-    public function extract($file, $target, $delete = false)
+    public function extract(string $file, string $target = '', bool $delete = false): bool
     {
         if (file_exists($file)) {
             // buffer size 4KB
@@ -54,15 +53,15 @@ class Bzip
     /**
      * Compress file into bzip.
      *
-     * @param (string) $file        file that you want compress
-     * @param (string) $destination destination
-     * @param (bool)d  $overwrite   true delete zip file false not delete
+     * @param (string) $file        The file that you want compress.
+     * @param (string) $destination The file destination.
+     * @param (bool)   $overwrite   True to delete the file; False to not delete it.
      *
      * @since 1.0.0
      *
      * @return bool
      */
-    public function compress($file, $destination = '', $overwrite = false)
+    public function compress(string $file, string = $destination = '', bool $overwrite = false): bool
     {
         //if the zip file already exists and overwrite is false, return false
         if (file_exists($destination) && !$overwrite) {

--- a/src/Archive/Adapter/Gzip.php
+++ b/src/Archive/Adapter/Gzip.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of the Zest Framework.
  *
@@ -17,20 +16,20 @@
 
 namespace Zest\Archive\Adapter;
 
-class Gzip
+class Gzip extends AdapterInterface
 {
     /**
-     * Open zip extract zip.
+     * Open and extract the archive.
      *
-     * @param (string) $file   file that you want uncompress/open
-     * @param (string) $target where you extract file
-     * @param (bool)   $delete true delete zip file false not delete
+     * @param (string) $file   The file that you want uncompress/open.
+     * @param (string) $target Where to extract the file.
+     * @param (bool)   $delete True to delete the file; False to not delete it.
      *
      * @since 1.0.0
      *
      * @return bool
      */
-    public function extract($file, $target, $delete = false)
+    public function extract(string $file, string $target = '', bool $delete = false): bool
     {
         if (file_exists($file)) {
             // buffer size 4KB
@@ -56,15 +55,15 @@ class Gzip
     /**
      * Compress file into bzip.
      *
-     * @param (string) $file        file that you want compress
-     * @param (string) $destination destination
-     * @param (bool)d  $overwrite   true delete zip file false not delete
+     * @param (string) $file        The file that you want compress.
+     * @param (string) $destination The file destination.
+     * @param (bool)   $overwrite   True to delete the file; False to not delete it.
      *
      * @since 1.0.0
      *
      * @return bool
      */
-    public function compress($file, $destination = '', $overwrite = false)
+    public function compress(string $file, string = $destination = '', bool $overwrite = false): bool
     {
         //if the zip file already exists and overwrite is false, return false
         if (file_exists($destination) && !$overwrite) {

--- a/src/Archive/Adapter/Zip.php
+++ b/src/Archive/Adapter/Zip.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of the Zest Framework.
  *
@@ -17,20 +16,20 @@
 
 namespace Zest\Archive\Adapter;
 
-class Zip
+class Zip extends AdapterInterface
 {
     /**
-     * Open zip extract zip.
+     * Open and extract the archive.
      *
-     * @param (string) $file   file that you want uncompress/open
-     * @param (string) $target where you extract file
-     * @param (bool)   $delete true delete zip file false not delete
+     * @param (string) $file   The file that you want uncompress/open.
+     * @param (string) $target Where to extract the file.
+     * @param (bool)   $delete True to delete the file; False to not delete it.
      *
      * @since 1.0.0
      *
      * @return bool
      */
-    public function extract($file, $target, $delete = false)
+    public function extract(string $file, string $target = '', bool $delete = false): bool
     {
         $zip = new \ZipArchive();
         $x = $zip->open($file);
@@ -46,17 +45,17 @@ class Zip
     }
 
     /**
-     * Compress file into zip.
+     * Compress the file to an archive.
      *
-     * @param (array) $file        file that you want compress
-     * @param (string) $destination destination
-     * @param (bool)d  $overwrite   true delete zip file false not delete
+     * @param (array)  $file        The file that you want compress.
+     * @param (string) $destination The file destination.
+     * @param (bool)   $overwrite   True to delete the file; False to not delete it.
      *
      * @since 1.0.0
      *
      * @return bool
      */
-    public function compress($files = [], $destination = '', $overwrite = false)
+    public function compress(array $files = [], string $destination = '', bool $overwrite = false): bool
     {
         //if the zip file already exists and overwrite is false, return false
         if (file_exists($destination) && !$overwrite) {

--- a/src/Archive/Archive.php
+++ b/src/Archive/Archive.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of the Zest Framework.
  *
@@ -9,13 +8,13 @@
  *
  * For the full copyright and license information, please view the LICENSE
  *  file that was distributed with this source code.
- * @since 3.0.0
  *
  * @license MIT
+ *
+ * @since 3.0.0
  */
 
 namespace Zest\Archive;
-
 
 class Archive
 {
@@ -29,7 +28,7 @@ class Archive
     private $adapter = null;
 
     /**
-     * __construct.
+     * The constructor.
      *
      * @since 3.0.0
      */
@@ -65,33 +64,33 @@ class Archive
     }
 
     /**
-     * Open zip extract zip.
+     * Open and extract the archive.
      *
-     * @param (string) $file   file that you want uncompress/open
-     * @param (string) $target where you extract file
-     * @param (bool)   $delete true delete zip file false not delete
+     * @param (string) $file   The file that you want uncompress/open.
+     * @param (string) $target Where to extract the file.
+     * @param (bool)   $delete True to delete the file; False to not delete it.
      *
      * @since 1.0.0
      *
      * @return bool
      */
-    public function extract($file, $target, $delete = false)
+    public function extract(string $file, string $target, bool $delete = false): bool
     {
         return $this->adapter->extract($file, $target, $delete);
     }
 
     /**
-     * Compress file into zip.
+     * Compress the file to an archive.
      *
-     * @param (mixed) $file        file that you want compress
-     * @param (string) $destination destination
-     * @param (bool)d  $overwrite   true delete zip file false not delete
+     * @param (mixed)  $files       The file(/s) that you want compress.
+     * @param (string) $destination The file destination.
+     * @param (bool)   $overwrite   True to delete the file; False to not delete it.
      *
      * @since 1.0.0
      *
      * @return bool
      */
-    public function compress($files, $destination = '', $overwrite = false)
+    public function compress($files, string $destination = '', bool $overwrite = false): bool
     {
         return $this->adapter->compress($files, $destination, $overwrite);
     }


### PR DESCRIPTION
When the intention exists to write numerous classes with the same or very similar methods, PHP interfaces are a useful means to ensure that accidents don't occur with method names in the future, and to ensure that such intentions are fully met insofar as such classes possessing the needed methods.

This pull request adds an adapter interface (this contributes towards the work currently being done at the `dev@220` branch). This pull request also slightly cleans up some of the PHPDoc comments, and adds both parameter type hints and return types to all methods which belong to the affected classes.