### PR TITLE
Adopt null coalescence.

### DIFF
--- a/src/http/HTTP.php
+++ b/src/http/HTTP.php
@@ -295,7 +295,7 @@ abstract class HTTP extends Headers
      */
     public function getRequestMethod()
     {
-        return (isset($_SERVER['REQUEST_METHOD'])) ? $_SERVER['REQUEST_METHOD'] : false;
+        return $_SERVER['REQUEST_METHOD'] ?? false;
     }
 
     /**
@@ -307,7 +307,7 @@ abstract class HTTP extends Headers
      */
     public function getRequestUrl()
     {
-        return (isset($_SERVER['REQUEST_URI'])) ? $_SERVER['REQUEST_URI'] : false;
+        return $_SERVER['REQUEST_URI'] ?? false;
     }
 
     /**
@@ -319,7 +319,7 @@ abstract class HTTP extends Headers
      */
     public function getContentType()
     {
-        return (isset($_SERVER['CONTENT_TYPE'])) ? $_SERVER['CONTENT_TYPE'] : false;
+        return $_SERVER['CONTENT_TYPE'] ?? false;
     }
 
     /**
@@ -331,7 +331,7 @@ abstract class HTTP extends Headers
      */
     public function getQueryString()
     {
-        return (isset($_SERVER['QUERY_STRING'])) ? $_SERVER['QUERY_STRING'] : false;
+        return $_SERVER['QUERY_STRING'] ?? false;
     }
 
     /**
@@ -343,7 +343,7 @@ abstract class HTTP extends Headers
      */
     public function getServerPort()
     {
-        return (isset($_SERVER['SERVER_PORT'])) ? $_SERVER['SERVER_PORT'] : false;
+        return $_SERVER['SERVER_PORT'] ?? false;
     }
 
     /**
@@ -355,7 +355,7 @@ abstract class HTTP extends Headers
      */
     public function getDocumentRoot()
     {
-        return (isset($_SERVER['DOCUMENT_ROOT'])) ? $_SERVER['DOCUMENT_ROOT'] : false;
+        return $_SERVER['DOCUMENT_ROOT'] ?? false;
     }
 
     /**
@@ -367,7 +367,7 @@ abstract class HTTP extends Headers
      */
     public function getHost()
     {
-        return (isset($_SERVER['HTTP_HOST'])) ? $_SERVER['HTTP_HOST'] : false;
+        return $_SERVER['HTTP_HOST'] ?? false;
     }
 
     /**
@@ -379,7 +379,7 @@ abstract class HTTP extends Headers
      */
     public function getServerName()
     {
-        return (isset($_SERVER['SERVER_NAME'])) ? $_SERVER['SERVER_NAME'] : false;
+        return $_SERVER['SERVER_NAME'] ?? false;
     }
 
     /**
@@ -391,7 +391,7 @@ abstract class HTTP extends Headers
      */
     public function gethttp()
     {
-        return (isset($_SERVER['HTTP'])) ? $_SERVER['HTTP'] : false;
+        return $_SERVER['HTTP'] ?? false;
     }
 
     /**
@@ -403,7 +403,7 @@ abstract class HTTP extends Headers
      */
     public function gethttps()
     {
-        return (isset($_SERVER['HTTPS'])) ? $_SERVER['HTTPS'] : false;
+        return $_SERVER['HTTPS'] ?? false;
     }
 
     /**
@@ -415,7 +415,7 @@ abstract class HTTP extends Headers
      */
     public function getSelf()
     {
-        return (isset($_SERVER['PHP_SELF'])) ? $_SERVER['PHP_SELF'] : false;
+        return $_SERVER['PHP_SELF'] ?? false;
     }
 
     /**
@@ -427,6 +427,6 @@ abstract class HTTP extends Headers
      */
     public function getReference()
     {
-        return (isset($_SERVER['HTTP_REFERER'])) ? $_SERVER['HTTP_REFERER'] : false;
+        return $_SERVER['HTTP_REFERER'] ?? false;
     }
 }

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -28,13 +28,13 @@ class Request extends Uri
     public function __construct()
     {
         parent::__construct();
-        $this->get = (isset($_GET)) ? $_GET : [];
-        $this->post = (isset($_POST)) ? $_POST : [];
-        $this->files = (isset($_FILES)) ? $_FILES : [];
-        $this->session = (isset($_SESSION)) ? $_SESSION : [];
-        $this->cookie = (isset($_COOKIE)) ? $_COOKIE : [];
-        $this->server = (isset($_SERVER)) ? $_SERVER : [];
-        $this->env = (isset($_ENV)) ? $_ENV : [];
+        $this->get = $_GET ?? [];
+        $this->post = $_POST ?? [];
+        $this->files = $_FILES ?? [];
+        $this->session = $_SESSION ?? [];
+        $this->cookie = $_COOKIE ?? [];
+        $this->server = $_SERVER ?? [];
+        $this->env = $_ENV ?? [];
 
         if ($this->getRequestMethod()) {
             $this->parseData();
@@ -184,7 +184,7 @@ class Request extends Uri
      */
     public function isSecure()
     {
-        return ($this->gethttps() || $this->getServerPort() && $this->getServerPort() == '443') ? true : false;
+        return ($this->gethttps() || $this->getServerPort() && $this->getServerPort() == '443');
     }
 
     /**

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -184,7 +184,7 @@ class Request extends Uri
      */
     public function isSecure()
     {
-        return ($this->gethttps() || $this->getServerPort() && $this->getServerPort() == '443');
+        return $this->gethttps() || $this->getServerPort() && $this->getServerPort() == '443';
     }
 
     /**


### PR DESCRIPTION
Since we've set the minimum PHP requirement for Zest to a more modern PHP version, we're able to take advantage of PHP's null coalescence operator, which in some cases can replace existing isset checks, meaning less code.